### PR TITLE
Update template.yaml to have expected core access options

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,8 +5,7 @@ variants:
       - name: main
         type: {{architecture}}
         core_access_options: !Arm
-          ap: 0x0
-          psel: 0x0
+          ap: !v1 1
     memory_map:
       - !Ram
           range:


### PR DESCRIPTION
The old 0x0 variant was no longer supported in target-gen. This fixes https://github.com/probe-rs/probe-rs/issues/3237